### PR TITLE
Optimize staff management loading and display

### DIFF
--- a/src/components/StaffManagement.tsx
+++ b/src/components/StaffManagement.tsx
@@ -122,6 +122,10 @@ export const StaffManagement = () => {
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [editingStaff, setEditingStaff] = useState<StaffMember | null>(null);
   const [activeTab, setActiveTab] = useState("staff");
+  const [hasLoadedRequests, setHasLoadedRequests] = useState(false);
+  const [hasLoadedAssets, setHasLoadedAssets] = useState(false);
+  const [hasLoadedActivity, setHasLoadedActivity] = useState(false);
+  const [hasLoadedNotifications, setHasLoadedNotifications] = useState(false);
   
   const [staffForm, setStaffForm] = useState({
     email: "",
@@ -133,21 +137,39 @@ export const StaffManagement = () => {
   });
 
   useEffect(() => {
-    if (canManageStaff()) {
-      fetchAllData();
-    }
+    if (!canManageStaff()) return;
+    const load = async () => {
+      setLoading(true);
+      await fetchStaff();
+      setLoading(false);
+    };
+    load();
   }, []);
+
+  useEffect(() => {
+    if (!canManageStaff()) return;
+    if (activeTab === 'requests' && !hasLoadedRequests) {
+      setHasLoadedRequests(true);
+      fetchServiceRequests();
+    }
+    if (activeTab === 'assets' && !hasLoadedAssets) {
+      setHasLoadedAssets(true);
+      fetchAssets();
+    }
+    if (activeTab === 'activity' && !hasLoadedActivity) {
+      setHasLoadedActivity(true);
+      fetchActivityLogs();
+    }
+    if (activeTab === 'notifications' && !hasLoadedNotifications) {
+      setHasLoadedNotifications(true);
+      fetchNotifications();
+    }
+  }, [activeTab, canManageStaff]);
 
   const fetchAllData = async () => {
     try {
       setLoading(true);
-      await Promise.all([
-        fetchStaff(),
-        fetchServiceRequests(),
-        fetchAssets(),
-        fetchActivityLogs(),
-        fetchNotifications()
-      ]);
+      await fetchStaff();
     } catch (error) {
       console.error('Error fetching data:', error);
     } finally {
@@ -214,7 +236,8 @@ export const StaffManagement = () => {
           user:profiles!fk_service_requests_user_id(first_name, last_name, email),
           assigned_technician:profiles!fk_service_requests_assigned_technician_id(first_name, last_name)
         `)
-        .order('created_at', { ascending: false });
+        .order('created_at', { ascending: false })
+        .limit(50);
 
       if (!error && data) {
         setServiceRequests(data);
@@ -239,7 +262,8 @@ export const StaffManagement = () => {
       const { data, error } = await supabase
         .from('assets')
         .select('*')
-        .order('created_at', { ascending: false });
+        .order('created_at', { ascending: false })
+        .limit(50);
 
       if (!error && data) {
         setAssets(data);
@@ -283,7 +307,8 @@ export const StaffManagement = () => {
       const { data, error } = await supabase
         .from('notifications')
         .select('*')
-        .order('created_at', { ascending: false });
+        .order('created_at', { ascending: false })
+        .limit(50);
 
       if (!error && data) {
         setNotifications(data);
@@ -308,23 +333,70 @@ export const StaffManagement = () => {
 
       switch (dataType) {
         case 'staff':
-          data = staff;
+          {
+            const { data: staffFull, error } = await supabase
+              .from('profiles')
+              .select(`
+                id,
+                first_name,
+                last_name,
+                email,
+                created_at,
+                user_roles (
+                  role,
+                  specialty
+                )
+              `)
+              .order('created_at', { ascending: false });
+            data = staffFull || staff;
+          }
           filename = `staff_export_${new Date().toISOString().split('T')[0]}.json`;
           break;
         case 'requests':
-          data = serviceRequests;
+          {
+            const { data: requestsFull, error } = await supabase
+              .from('service_requests')
+              .select(`
+                *,
+                user:profiles!fk_service_requests_user_id(first_name, last_name, email),
+                assigned_technician:profiles!fk_service_requests_assigned_technician_id(first_name, last_name)
+              `)
+              .order('created_at', { ascending: false });
+            data = requestsFull || serviceRequests;
+          }
           filename = `service_requests_export_${new Date().toISOString().split('T')[0]}.json`;
           break;
         case 'assets':
-          data = assets;
+          {
+            const { data: assetsFull, error } = await supabase
+              .from('assets')
+              .select('*')
+              .order('created_at', { ascending: false });
+            data = assetsFull || assets;
+          }
           filename = `assets_export_${new Date().toISOString().split('T')[0]}.json`;
           break;
         case 'activity':
-          data = activityLogs;
+          {
+            const { data: activityFull, error } = await supabase
+              .from('activity_logs')
+              .select(`
+                *,
+                user:profiles!fk_activity_logs_user_id(first_name, last_name)
+              `)
+              .order('created_at', { ascending: false });
+            data = activityFull || activityLogs;
+          }
           filename = `activity_logs_export_${new Date().toISOString().split('T')[0]}.json`;
           break;
         case 'notifications':
-          data = notifications;
+          {
+            const { data: notificationsFull, error } = await supabase
+              .from('notifications')
+              .select('*')
+              .order('created_at', { ascending: false });
+            data = notificationsFull || notifications;
+          }
           filename = `notifications_export_${new Date().toISOString().split('T')[0]}.json`;
           break;
       }
@@ -457,7 +529,7 @@ export const StaffManagement = () => {
         description: "Staff role updated successfully"
       });
 
-      fetchAllData();
+      fetchStaff();
     } catch (error) {
       console.error('Error updating staff role:', error);
     }
@@ -481,7 +553,7 @@ export const StaffManagement = () => {
         description: "Staff member deleted successfully"
       });
 
-      fetchAllData();
+      fetchStaff();
     } catch (error) {
       console.error('Error deleting staff member:', error);
     }


### PR DESCRIPTION
Implement lazy loading for Staff Management tabs and add query limits to improve initial page load performance.

The Staff Management page was slow to load because it fetched all data (staff, requests, assets, activity, notifications) on initial mount. This change defers fetching data for non-staff tabs until they are actively selected, and limits the initial query size for heavy lists. Export functionality now fetches full datasets directly from the database when requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d804541-1236-4cd4-b530-9c24793d3e87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8d804541-1236-4cd4-b530-9c24793d3e87">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

